### PR TITLE
Add getZoom function with resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.venv/
 env/
 build/
 develop-eggs/
@@ -60,3 +61,6 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+# Vim temporary files
+*.swp

--- a/gatilegrid/tilegrids.py
+++ b/gatilegrid/tilegrids.py
@@ -231,6 +231,11 @@ class _TileGrid(object):
         "Return the image resolution at a given zoom level"
         return self.tileSize(zoom) / self.tileSizePx
 
+    def getZoom(self, resolution):
+        "Return the zoom level for a given resolution"
+        assert resolution in self.RESOLUTIONS
+        return self.RESOLUTIONS.index(resolution)
+
     def getScale(self, zoom, dpi=96.0):
         "Return the scale at a given zoom level \
         (1:x e.g. 1 map unit equal x unit in the real world)"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 
 setup(name='gatilegrid',
-      version='0.1.0',
+      version='0.1.1',
       description='Popular tile grids and grids API for web mapping applications',
       classifiers=[],
       keywords='',

--- a/tests/test_tilegrids.py
+++ b/tests/test_tilegrids.py
@@ -48,6 +48,34 @@ class TestGeoadminTileGrid(unittest.TestCase):
         with self.assertRaises(AssertionError):
             gagrid.tileSize(40)
 
+    def testGetResolution(self):
+        gagrid = GeoadminTileGridLV95()
+        res = gagrid.getResolution(0)
+        self.assertEqual(res, 4000.0)
+        res = gagrid.getResolution(28)
+        self.assertEqual(res, 0.1)
+
+        with self.assertRaises(AssertionError):
+            gagrid.getResolution(-1)
+        with self.assertRaises(AssertionError):
+            gagrid.getResolution(29)
+
+    def testGetZoom(self):
+        gagrid = GeoadminTileGridLV95()
+        zoom = gagrid.getZoom(4000.0)
+        self.assertEqual(zoom, 0)
+        zoom = gagrid.getZoom(0.1)
+        self.assertEqual(zoom, 28)
+
+        with self.assertRaises(AssertionError):
+            gagrid.getZoom(4000.000001)
+        with self.assertRaises(AssertionError):
+            gagrid.getZoom(3999.999999)
+        with self.assertRaises(AssertionError):
+            gagrid.getZoom(0.1000001)
+        with self.assertRaises(AssertionError):
+            gagrid.getZoom(0.00000001)
+
     def testTileBoundsAndAddress(self):
         gagrid = GeoadminTileGridLV03()
         tbe = [548000.0, 196400.0, 573600.0, 222000.0]


### PR DESCRIPTION
@loicgasser We need this function as we don't have the zoom information anymore in our backend.

So we need to determine it from the resolution.

See https://github.com/geoadmin/tool-wms/pull/91

Can you quickly review, merge and upload? I need it for https://github.com/geoadmin/mf-chsdi3/issues/2627