### PR TITLE
Use the ogc standerized px size for scale computation

### DIFF
--- a/gatilegrid/tilegrids.py
+++ b/gatilegrid/tilegrids.py
@@ -279,11 +279,13 @@ class _TileGrid(object):
             return lo
         return lo - 1
 
-    def getScale(self, zoom, dpi=96.0):
-        "Return the scale at a given zoom level \
-        (1:x e.g. 1 map unit equal x unit in the real world)"
-        inchesPerMeters = 39.37
-        return self.getResolution(zoom) * inchesPerMeters * dpi
+    def getScale(self, zoom):
+        if self.unit == 'degrees':
+            resolution = self.getResolution(zoom) * EPSG4326_METERS_PER_UNIT
+        else:
+            resolution = self.getResolution(zoom)
+        stdRendPxSize = 0.00028
+        return resolution / stdRendPxSize
 
     def getExtentAddress(self, zoom):
         minX = self.extent[0]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 
 setup(name='gatilegrid',
-      version='0.1.4',
+      version='0.1.5',
       description='Popular tile grids and grids API for web mapping applications',
       classifiers=[],
       keywords='',

--- a/tests/test_tilegrids.py
+++ b/tests/test_tilegrids.py
@@ -156,16 +156,16 @@ class TestGeoadminTileGrid(unittest.TestCase):
         s14 = gagrid.getScale(14)
         s28 = gagrid.getScale(28)
         self.assertGreater(s14, s28)
-        self.assertEqual(round(s14), 2456688.0)
-        self.assertEqual(round(s28), 378.0)
+        self.assertEqual(round(s14), 2321429.0)
+        self.assertEqual(round(s28), 357.0)
 
     def testGetScaleLV95(self):
         gagrid = GeoadminTileGridLV95()
         s14 = gagrid.getScale(14)
         s28 = gagrid.getScale(28)
         self.assertGreater(s14, s28)
-        self.assertEqual(round(s14), 2456688.0)
-        self.assertEqual(round(s28), 378.0)
+        self.assertEqual(round(s14), 2321429.0)
+        self.assertEqual(round(s28), 357.0)
 
     def testIterGridWithExtent(self):
         offset = 20000.0


### PR DESCRIPTION
According to OCG standards we should use the standardized rendering px size for scale computation.
http://wiki.deegree.org/deegreeWiki/HowToUseScaleHintAndScaleDenominator
http://portal.opengeospatial.org/files/?artifact_id=14416

This makes our getCap a little bit more accurate.