### PR TITLE
Add default ch bbox for non-swiss prjs and intersectsExtent method

### DIFF
--- a/gatilegrid/tilegrids.py
+++ b/gatilegrid/tilegrids.py
@@ -52,6 +52,11 @@ class _LV03Base(_ResolutionsBase):
     MINY = 30000.0
     MAXY = 350000.0
 
+    MINXCH = MINX
+    MINYCH = MINY
+    MAXXCH = MAXX
+    MAXYCH = MAXY
+
     spatialReference = 21781
 
     tileAddressTemplate = '{zoom}/{tileRow}/{tileCol}'
@@ -67,6 +72,11 @@ class _LV95Base(_ResolutionsBase):
     MAXX = 2900000.0
     MINY = 1030000.0
     MAXY = 1350000.0
+
+    MINXCH = MINX
+    MINYCH = MINY
+    MAXXCH = MAXX
+    MAXYCH = MAXY
 
     spatialReference = 2056
 
@@ -112,6 +122,11 @@ class _MercatorBase:
     MINY = -20037508.342789244
     MAXY = 20037508.342789244
 
+    MINXCH = 572215.498516761
+    MINYCH = 5684416.883038491
+    MAXXCH = 1277662.4228336029
+    MAXYCH = 6145307.311301859
+
     spatialReference = 3857
 
     tileAddressTemplate = '{zoom}/{tileCol}/{tileRow}'
@@ -127,6 +142,11 @@ class _GeodeticBase:
     MAXX = 180.0
     MINY = -90.0  # lat
     MAXY = 90.0
+
+    MINXCH = 5.1402992812767865
+    MINYCH = 45.398121743782234
+    MAXXCH = 11.477436823766046
+    MAXYCH = 48.23061646466063
 
     spatialReference = 4326
 
@@ -147,7 +167,7 @@ class _GeodeticBase:
 class _TileGrid(object):
 
     def __init__(self, extent=None, tileSizePx=256.0, originCorner='top-left',
-                 tmsCompatible=None):
+                 tmsCompatible=None, useSwissExtent=True):
         assert originCorner in ('bottom-left', 'top-left')
         self.originCorner = originCorner
 
@@ -162,6 +182,8 @@ class _TileGrid(object):
             assert extent[2] <= self.MAXX
             assert extent[3] <= self.MAXY
             self.extent = extent
+        elif useSwissExtent:
+            self.extent = [self.MINXCH, self.MINYCH, self.MAXXCH, self.MAXYCH]
         else:
             self.extent = [self.MINX, self.MINY, self.MAXX, self.MAXY]
         if self.originCorner == 'bottom-left':
@@ -196,8 +218,8 @@ class _TileGrid(object):
         "Returns a tile address based on a zoom level and \
         a point in the tile"
         [x, y] = point
-        assert x <= self.MAXX and x >= self.MINX
-        assert y <= self.MAXY and y >= self.MINY
+        assert x <= self.extent[2] and x >= self.extent[0]
+        assert y <= self.extent[3] and y >= self.extent[1]
         assert zoom in range(0, len(self.RESOLUTIONS))
 
         tileS = self.tileSize(zoom)
@@ -217,6 +239,11 @@ class _TileGrid(object):
             int(math.floor(col)),
             int(math.floor(row))
         ]
+
+    def intersectsExtent(self, extent):
+        return \
+            self.extent[0] <= extent[2] and self.extent[2] >= extent[0] and \
+            self.extent[1] <= extent[3] and self.extent[3] >= extent[1]
 
     def iterGrid(self, minZoom, maxZoom):
         "Yields the tileBounds, zoom, tileCol and tileRow"
@@ -313,37 +340,65 @@ class _TileGrid(object):
 
 class GeoadminTileGridLV03(_LV03Base, _TileGrid):
 
-    def __init__(self, extent=None, tileSizePx=256.0, originCorner='top-left'):
+    def __init__(self,
+                 extent=None,
+                 tileSizePx=256.0,
+                 originCorner='top-left',
+                 useSwissExtent=True):
 
         super(GeoadminTileGridLV03, self).__init__(
-            extent=extent, tileSizePx=tileSizePx, originCorner=originCorner
+            extent=extent,
+            tileSizePx=tileSizePx,
+            originCorner=originCorner,
+            useSwissExtent=useSwissExtent
         )
 
 
 class GeoadminTileGridLV95(_LV95Base, _TileGrid):
 
-    def __init__(self, extent=None, tileSizePx=256.0, originCorner='top-left'):
+    def __init__(self,
+                 extent=None,
+                 tileSizePx=256.0,
+                 originCorner='top-left',
+                 useSwissExtent=True):
 
         super(GeoadminTileGridLV95, self).__init__(
-            extent=extent, tileSizePx=tileSizePx, originCorner=originCorner
+            extent=extent,
+            tileSizePx=tileSizePx,
+            originCorner=originCorner,
+            useSwissExtent=useSwissExtent
         )
 
 
 class GlobalMercatorTileGrid(_MercatorBase, _TileGrid):
 
-    def __init__(self, extent=None, tileSizePx=256.0, originCorner='top-left'):
+    def __init__(self,
+                 extent=None,
+                 tileSizePx=256.0,
+                 originCorner='top-left',
+                 useSwissExtent=True):
 
         super(GlobalMercatorTileGrid, self).__init__(
-            extent=extent, tileSizePx=tileSizePx, originCorner=originCorner
+            extent=extent,
+            tileSizePx=tileSizePx,
+            originCorner=originCorner,
+            useSwissExtent=useSwissExtent
         )
 
 
 class GlobalGeodeticTileGrid(_GeodeticBase, _TileGrid):
 
-    def __init__(self, extent=None, tileSizePx=256.0, originCorner='top-left',
-                 tmsCompatible=True):
+    def __init__(self,
+                 extent=None,
+                 tileSizePx=256.0,
+                 originCorner='top-left',
+                 tmsCompatible=True,
+                 useSwissExtent=True):
 
         super(GlobalGeodeticTileGrid, self).__init__(
-            extent=extent, tileSizePx=tileSizePx, originCorner=originCorner,
-            tmsCompatible=tmsCompatible
+            extent=extent,
+            tileSizePx=tileSizePx,
+            originCorner=originCorner,
+            tmsCompatible=tmsCompatible,
+            useSwissExtent=useSwissExtent
         )

--- a/gatilegrid/tilegrids.py
+++ b/gatilegrid/tilegrids.py
@@ -241,6 +241,7 @@ class _TileGrid(object):
         ]
 
     def intersectsExtent(self, extent):
+        "Determine if an extent intersects this instance extent"
         return \
             self.extent[0] <= extent[2] and self.extent[2] >= extent[0] and \
             self.extent[1] <= extent[3] and self.extent[3] >= extent[1]
@@ -272,6 +273,18 @@ class _TileGrid(object):
         "Returns the total number of tile at a given zoom level"
         [minRow, minCol, maxRow, maxCol] = self.getExtentAddress(zoom)
         return (maxCol - minCol + 1) * (maxRow - minRow + 1)
+
+    def totalNumberOfTiles(self, minZoom=None, maxZoom=None):
+        "Return the total number of tiles for this instance extent"
+        nbTiles = 0
+        minZoom = minZoom or 0
+        if maxZoom:
+            maxZoom = maxZoom + 1
+        else:
+            maxZoom = len(self.RESOLUTIONS)
+        for zoom in xrange(minZoom, maxZoom):
+            nbTiles += self.numberOfTilesAtZoom(zoom)
+        return nbTiles
 
     def getResolution(self, zoom):
         "Return the image resolution at a given zoom level"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ except ImportError:
 
 
 setup(name='gatilegrid',
-      version='0.1.5',
+      version='0.1.6',
       description='Popular tile grids and grids API for web mapping applications',
       classifiers=[],
       keywords='',

--- a/tests/test_tilegrids.py
+++ b/tests/test_tilegrids.py
@@ -212,6 +212,45 @@ class TestGeoadminTileGrid(unittest.TestCase):
         self.assertEqual(nb, nbx * nby)
         self.assertGreater(nbx, nby)
 
+    def testTotalNumberOfTilesLV03(self):
+        zoom = 20
+        gagrid = GeoadminTileGridLV03()
+
+        [minRow, minCol, maxRow, maxCol] = gagrid.getExtentAddress(zoom)
+        nb20 = gagrid.numberOfTilesAtZoom(zoom)
+        nbx = gagrid.numberOfXTilesAtZoom(zoom)
+        nby = gagrid.numberOfYTilesAtZoom(zoom)
+        self.assertGreater(maxCol, maxRow)
+        self.assertEqual(len([t for t in gagrid.iterGrid(zoom, zoom)]), nb20)
+        self.assertEqual(nb20, 23500)
+        self.assertEqual(nb20, nbx * nby)
+        self.assertGreater(nbx, nby)
+
+        zoom = 21
+        [minRow, minCol, maxRow, maxCol] = gagrid.getExtentAddress(zoom)
+        nb21 = gagrid.numberOfTilesAtZoom(zoom)
+        nbx = gagrid.numberOfXTilesAtZoom(zoom)
+        nby = gagrid.numberOfYTilesAtZoom(zoom)
+        self.assertGreater(maxCol, maxRow)
+        self.assertEqual(len([t for t in gagrid.iterGrid(zoom, zoom)]), nb21)
+        self.assertEqual(nb21, 93750)
+        self.assertEqual(nb21, nbx * nby)
+        self.assertGreater(nbx, nby)
+
+        zoom = 22
+        [minRow, minCol, maxRow, maxCol] = gagrid.getExtentAddress(zoom)
+        nb22 = gagrid.numberOfTilesAtZoom(zoom)
+        nbx = gagrid.numberOfXTilesAtZoom(zoom)
+        nby = gagrid.numberOfYTilesAtZoom(zoom)
+        self.assertGreater(maxCol, maxRow)
+        self.assertEqual(len([t for t in gagrid.iterGrid(zoom, zoom)]), nb22)
+        self.assertEqual(nb22, 375000)
+        self.assertEqual(nb22, nbx * nby)
+        self.assertGreater(nbx, nby)
+
+        self.assertEqual(gagrid.totalNumberOfTiles(20, 22), nb20 + nb21 + nb22)
+        self.assertEqual(gagrid.totalNumberOfTiles(), 285721952)
+
     def testNumberOfTilesLV95(self):
         zoom = 20
         gagrid = GeoadminTileGridLV95()

--- a/tests/test_tilegrids.py
+++ b/tests/test_tilegrids.py
@@ -77,7 +77,7 @@ class TestGeoadminTileGrid(unittest.TestCase):
             gagrid.getZoom(0.00000001)
 
     def testGetClosestZoom(self):
-        gagrid = GeoadminTileGridLV95()
+        gagrid = GeoadminTileGridLV95(useSwissExtent=False)
         zoom = gagrid.getClosestZoom(100000.5)
         self.assertEqual(zoom, 0)
         self.assertIsInstance(zoom, int)
@@ -91,7 +91,7 @@ class TestGeoadminTileGrid(unittest.TestCase):
         self.assertEqual(zoom, 28)
         self.assertIsInstance(zoom, int)
         # Test WGS84 degrees conversion
-        gagrid = GlobalGeodeticTileGrid()
+        gagrid = GlobalGeodeticTileGrid(useSwissExtent=False)
         # Input meters
         zoom = gagrid.getClosestZoom(600)
         self.assertEqual(zoom, 7)
@@ -237,7 +237,7 @@ class TestGeoadminTileGrid(unittest.TestCase):
         self.assertGreater(nbx, nby)
 
     def testNumberOfTilesMercator(self):
-        grid = GlobalMercatorTileGrid()
+        grid = GlobalMercatorTileGrid(useSwissExtent=False)
         zoom = 0
         nb = grid.numberOfTilesAtZoom(zoom)
         nbx = grid.numberOfXTilesAtZoom(zoom)
@@ -258,7 +258,8 @@ class TestGeoadminTileGrid(unittest.TestCase):
 
     def testNumberOfTilesGeodetic(self):
         grid = GlobalGeodeticTileGrid(originCorner='bottom-left',
-                                      tmsCompatible=False)
+                                      tmsCompatible=False,
+                                      useSwissExtent=False)
         zoom = 0
         nb = grid.numberOfTilesAtZoom(zoom)
         nbx = grid.numberOfXTilesAtZoom(zoom)
@@ -278,7 +279,7 @@ class TestGeoadminTileGrid(unittest.TestCase):
         self.assertEqual(nb, 8)
 
         grid = GlobalGeodeticTileGrid(originCorner='bottom-left',
-                                      tmsCompatible=True)
+                                      tmsCompatible=True, useSwissExtent=False)
         zoom = 0
         nb = grid.numberOfTilesAtZoom(zoom)
         nbx = grid.numberOfXTilesAtZoom(zoom)
@@ -286,8 +287,27 @@ class TestGeoadminTileGrid(unittest.TestCase):
         self.assertEqual(nb, nbx * nby)
         self.assertEqual(nb, 2)
 
+    def testGeodeticGridSwissBounds(self):
+        grid = GlobalGeodeticTileGrid(useSwissExtent=True)
+        outsideCh = [2.2, 43.1, 2.3, 43.2]
+        withinCh = [6.7, 46.3, 6.8, 46.4]
+
+        self.assertFalse(grid.intersectsExtent(outsideCh))
+        self.assertTrue(grid.intersectsExtent(withinCh))
+        with self.assertRaises(AssertionError):
+            grid.tileAddress(5, [outsideCh[0], outsideCh[1]])
+        with self.assertRaises(AssertionError):
+            grid.tileAddress(5, [outsideCh[2], outsideCh[3]])
+        grid.tileAddress(5, [withinCh[0], withinCh[1]])
+        grid.tileAddress(5, [withinCh[2], withinCh[3]])
+
+        withinCh = [2.2, 43.1, 6.8, 46.4]
+        outsideCh = [2.2, 46.3, 2.3, 46.4]
+        self.assertTrue(grid.intersectsExtent(withinCh))
+        self.assertFalse(grid.intersectsExtent(outsideCh))
+
     def testMercatorGridBoundsAndAddress(self):
-        grid = GlobalMercatorTileGrid()
+        grid = GlobalMercatorTileGrid(useSwissExtent=False)
         [z, x, y] = [8, 135, 91]
         [xmin, ymin, xmax, ymax] = grid.tileBounds(z, x, y)
         self.assertAlmostEqual(xmin, 1095801.2374962866)
@@ -303,7 +323,7 @@ class TestGeoadminTileGrid(unittest.TestCase):
 
     def testGeodeticGridBoundsAndAddress(self):
         grid = GlobalGeodeticTileGrid(originCorner='top-left',
-                                      tmsCompatible=True)
+                                      tmsCompatible=True, useSwissExtent=False)
         [z, x, y] = [8, 268, 60]
         [xmin, ymin, xmax, ymax] = grid.tileBounds(z, x, y)
         self.assertAlmostEqual(xmin, 8.4375)
@@ -319,7 +339,7 @@ class TestGeoadminTileGrid(unittest.TestCase):
 
         [z, x, y] = [8, 266, 193]
         grid = GlobalGeodeticTileGrid(originCorner='bottom-left',
-                                      tmsCompatible=True)
+                                      tmsCompatible=True, useSwissExtent=False)
         [xmin, ymin, xmax, ymax] = grid.tileBounds(z, x, y)
         self.assertAlmostEqual(xmin, 7.03125)
         self.assertAlmostEqual(ymin, 45.703125)

--- a/tests/test_tilegrids.py
+++ b/tests/test_tilegrids.py
@@ -306,6 +306,25 @@ class TestGeoadminTileGrid(unittest.TestCase):
         self.assertTrue(grid.intersectsExtent(withinCh))
         self.assertFalse(grid.intersectsExtent(outsideCh))
 
+    def testMercatorGridSwissBounds(self):
+        grid = GlobalMercatorTileGrid(useSwissExtent=True)
+        outsideCh = [502215, 5084416, 512215, 5184416]
+        withinCh = [582215, 5784416, 592215, 5884416]
+
+        self.assertFalse(grid.intersectsExtent(outsideCh))
+        self.assertTrue(grid.intersectsExtent(withinCh))
+        with self.assertRaises(AssertionError):
+            grid.tileAddress(5, [outsideCh[0], outsideCh[1]])
+        with self.assertRaises(AssertionError):
+            grid.tileAddress(5, [outsideCh[2], outsideCh[3]])
+        grid.tileAddress(5, [withinCh[0], withinCh[1]])
+        grid.tileAddress(5, [withinCh[2], withinCh[3]])
+
+        withinCh = [502215, 5084416, 592215, 5884416]
+        outsideCh = [582215, 5084416, 592215, 5184416]
+        self.assertTrue(grid.intersectsExtent(withinCh))
+        self.assertFalse(grid.intersectsExtent(outsideCh))
+
     def testMercatorGridBoundsAndAddress(self):
         grid = GlobalMercatorTileGrid(useSwissExtent=False)
         [z, x, y] = [8, 135, 91]


### PR DESCRIPTION
This PR adds 2 new methods to the `_TileGrid` class namely:

- `intersectsExtent(extent)` which returns a boolean value if the extent provided intersects the current instance. This method will then be used in `service-proxywms` to validate the tile addresses in all projections.
- `totalNumberOfTiles(minZoom, maxZoom)` which is a convinient way to calculate the number of tiles we're about to generate or delete. `totalNumberOfTiles()` simply returns the  total number of tiles for all zoom levels.

I added a new argument to all tile grid instances `useSwissExtent` which is set to `True` per default.

This is useful when dealing with global pyramid definitions.

ping @ltclm 