### PR TITLE
getCeilingZoom + Tests

### DIFF
--- a/gatilegrid/tilegrids.py
+++ b/gatilegrid/tilegrids.py
@@ -297,13 +297,8 @@ class _TileGrid(object):
         assert resolution in self.RESOLUTIONS
         return self.RESOLUTIONS.index(resolution)
 
-    def getClosestZoom(self, resolution, unit='meters'):
-        """
-        Return the closest zoom level for a given resolution
-        Parameters:
-            resolution -- max. resolution
-            unit -- unit for output (default='meters')
-        """
+    def getZoomLevelRange(self, resolution, unit='meters'):
+        "Return lower and higher zoom level given a resolution"
         assert unit in ('meters', 'degrees')
         if unit == 'meters' and self.unit == 'degrees':
             resolution = resolution / self.metersPerUnit
@@ -317,6 +312,16 @@ class _TileGrid(object):
                 hi = mid
             else:
                 lo = mid + 1
+        return lo, hi
+
+    def getClosestZoom(self, resolution, unit='meters'):
+        """
+        Return the closest zoom level for a given resolution
+        Parameters:
+            resolution -- max. resolution
+            unit -- unit for output (default='meters')
+        """
+        lo, hi = self.getZoomLevelRange(resolution, unit)
         if lo == 0:
             return lo
         if hi == len(self.RESOLUTIONS):
@@ -333,19 +338,7 @@ class _TileGrid(object):
             resolution -- max. resolution
             unit -- unit for output (default='meters')
         """
-        assert unit in ('meters', 'degrees')
-        if unit == 'meters' and self.unit == 'degrees':
-            resolution = resolution / self.metersPerUnit
-        elif unit == 'degrees' and self.unit == 'meters':
-            resolution = resolution * EPSG4326_METERS_PER_UNIT
-        lo = 0
-        hi = len(self.RESOLUTIONS)
-        while lo < hi:
-            mid = (lo + hi) // 2
-            if resolution > self.RESOLUTIONS[mid]:
-                hi = mid
-            else:
-                lo = mid + 1
+        lo, hi = self.getZoomLevelRange(resolution, unit)
         if lo == 0:
             return lo
         if hi == len(self.RESOLUTIONS):

--- a/gatilegrid/tilegrids.py
+++ b/gatilegrid/tilegrids.py
@@ -297,7 +297,7 @@ class _TileGrid(object):
         assert resolution in self.RESOLUTIONS
         return self.RESOLUTIONS.index(resolution)
 
-    def getZoomLevelRange(self, resolution, unit='meters'):
+    def _getZoomLevelRange(self, resolution, unit='meters'):
         "Return lower and higher zoom level given a resolution"
         assert unit in ('meters', 'degrees')
         if unit == 'meters' and self.unit == 'degrees':
@@ -321,7 +321,7 @@ class _TileGrid(object):
             resolution -- max. resolution
             unit -- unit for output (default='meters')
         """
-        lo, hi = self.getZoomLevelRange(resolution, unit)
+        lo, hi = self._getZoomLevelRange(resolution, unit)
         if lo == 0:
             return lo
         if hi == len(self.RESOLUTIONS):
@@ -338,7 +338,7 @@ class _TileGrid(object):
             resolution -- max. resolution
             unit -- unit for output (default='meters')
         """
-        lo, hi = self.getZoomLevelRange(resolution, unit)
+        lo, hi = self._getZoomLevelRange(resolution, unit)
         if lo == 0:
             return lo
         if hi == len(self.RESOLUTIONS):

--- a/gatilegrid/tilegrids.py
+++ b/gatilegrid/tilegrids.py
@@ -298,7 +298,12 @@ class _TileGrid(object):
         return self.RESOLUTIONS.index(resolution)
 
     def getClosestZoom(self, resolution, unit='meters'):
-        "Return the closest zoom level for a given resolution"
+        """
+        Return the closest zoom level for a given resolution
+        Parameters:
+            resolution -- max. resolution
+            unit -- unit for output (default='meters')
+        """
         assert unit in ('meters', 'degrees')
         if unit == 'meters' and self.unit == 'degrees':
             resolution = resolution / self.metersPerUnit
@@ -319,6 +324,32 @@ class _TileGrid(object):
         before = self.RESOLUTIONS[lo - 1]
         if abs(self.RESOLUTIONS[lo] - resolution) < abs(before - resolution):
             return lo
+        return lo - 1
+
+    def getCeilingZoom(self, resolution, unit='meters'):
+        """
+        Return the closest zoom level for a given resolution
+        Parameters:
+            resolution -- max. resolution
+            unit -- unit for output (default='meters')
+        """
+        assert unit in ('meters', 'degrees')
+        if unit == 'meters' and self.unit == 'degrees':
+            resolution = resolution / self.metersPerUnit
+        elif unit == 'degrees' and self.unit == 'meters':
+            resolution = resolution * EPSG4326_METERS_PER_UNIT
+        lo = 0
+        hi = len(self.RESOLUTIONS)
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if resolution > self.RESOLUTIONS[mid]:
+                hi = mid
+            else:
+                lo = mid + 1
+        if lo == 0:
+            return lo
+        if hi == len(self.RESOLUTIONS):
+            return hi - 1
         return lo - 1
 
     def getScale(self, zoom):

--- a/tests/test_tilegrids.py
+++ b/tests/test_tilegrids.py
@@ -101,6 +101,33 @@ class TestGeoadminTileGrid(unittest.TestCase):
         zoom = gagrid.getClosestZoom(0.021, unit='degrees')
         self.assertEqual(zoom, 5)
 
+    def testGetCeilingZoom(self):
+        gagrid = GeoadminTileGridLV95(useSwissExtent=False)
+        zoom = gagrid.getCeilingZoom(100000.5)
+        self.assertEqual(zoom, 0)
+        self.assertIsInstance(zoom, int)
+        zoom = gagrid.getCeilingZoom(2555.5)
+        self.assertEqual(zoom, 5)
+        self.assertIsInstance(zoom, int)
+        zoom = gagrid.getCeilingZoom(2500)
+        self.assertEqual(zoom, 6)
+        self.assertIsInstance(zoom, int)
+        zoom = gagrid.getCeilingZoom(0.09)
+        self.assertEqual(zoom, 28)
+        self.assertIsInstance(zoom, int)
+        # Test WGS84 degrees conversion
+        gagrid = GlobalGeodeticTileGrid(useSwissExtent=False)
+        # Input meters
+        zoom = gagrid.getCeilingZoom(600)
+        self.assertEqual(zoom, 7)
+        zoom = gagrid.getCeilingZoom(310)
+        self.assertEqual(zoom, 7)
+        zoom = gagrid.getCeilingZoom(0.29)
+        self.assertEqual(zoom, 18)
+        # Input degrees
+        zoom = gagrid.getCeilingZoom(0.021, unit='degrees')
+        self.assertEqual(zoom, 5)
+
     def testTileBoundsAndAddress(self):
         gagrid = GeoadminTileGridLV03()
         tbe = [548000.0, 196400.0, 573600.0, 222000.0]


### PR DESCRIPTION
Function to get the upper zoom level instead of the closest (see function `getClostestZoom`).